### PR TITLE
ARGO-3884  Release connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,6 @@
 
 ## [2.0.0] - 2022-02-10
 
-* ARGO-3375 Pass contacts for each topology entity
-* ARGO-3427 Fetch HOSTDN service attribute from GOCDB
-* ARGO-3428 Fetch SE_PATH from BDII
-* ARGO-3448 NEANIAS dulpicates in group topology
-* ARGO-3503 Support multiple VO SE_PATHs for host
-* ARGO-3521 Retry on empty responses
-* ARGO-3522 Introduce optional scope key for topology fetch and BIOMED feed parse
-* ARGO-3524 Improve exception handling
-* ARGO-3528 Verbose retry log messages
-* ARGO-3540 Tests for retry logic
-
 ### Added
 
 * ARGO-2620 Update connectors configuration templates
@@ -24,6 +13,11 @@
 * ARGO-3335 Retry on LDAP queries
 * ARGO-3340 Unit testing of parsing of GOCDB service endpoint
 * ARGO-3341 Pass date argument to WEB-API methods
+* ARGO-3375 Pass contacts for each topology entity
+* ARGO-3427 Fetch HOSTDN service attribute from GOCDB
+* ARGO-3428 Fetch SE_PATH from BDII
+* ARGO-3522 Introduce optional scope key for topology fetch and BIOMED feed parse
+* ARGO-3540 Tests for retry logic
 
 ### Fixed
 
@@ -32,6 +26,8 @@
 * ARGO-2681 Weights use HTTP PUT to write new daily entries
 * ARGO-2771 Weight connector issues investigated
 * ARGO-3268 Downtimes DELETE with explicit date passed
+* ARGO-3448 NEANIAS dulpicates in group topology
+* ARGO-3503 Support multiple VO SE_PATHs for host
 
 ### Changed
 
@@ -41,3 +37,6 @@
 * ARGO-2656 Downtimes as global tenant resource
 * ARGO-2860 Separate connection, parsing and file handling
 * ARGO-2861 Switch to async IO operations
+* ARGO-3521 Retry on empty responses
+* ARGO-3524 Improve exception handling
+* ARGO-3528 Verbose retry log messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [2.1.0] - 2022-06-07
+
+### Added
+
+* ARGO-2862 Introduce topo, weights, downtimes and metricprofile individual async tasks
+* ARGO-3583 Add support in Connectors for EOSC Providers Portal API
+* ARGO-3666 Introduce service type and descriptions fetch
+* ARGO-3700 EOSC topology service endpoints with only one hardcoded service for start
+* ARGO-3803 Use id as a service group name for EOSC PROVIDER topology
+* ARGO-3818 Use id as a project name for EOSC PROVIDER topology instead of abbreviation
+* ARGO-3849 Fetch monitoring extensions
+
+### Fixed
+
+* ARGO-3708 EOSCPROVIDER contacs is wrongly populated with one contact for every different endpoint
+* ARGO-3858 Slow performance with mesh of contacts data for EOSCPROVIDER topo
+* ARGO-3861 Some of endpoints are skipped if multiple endpoints are defined for the same resource on service-extensions
+* ARGO-3866 EOSC topology issue when defining two endpoints with the same hostname/service-type through monitoring extensions
+* ARGO-3869 Strip port from extracted hostname in group endpoints
+
+### Changed
+
+* ARGO-3842 Rename py modules and pkg to argo-connectors
+* ARGO-3846 Do not assume first fetch with paginated indexes succesfull
+* ARGO-3855 Join error lines for PROVIDER topology
+* ARGO-3856 find_next_paging_cursor_count for GOCDB topo task implies succesfull parse
+
 ## [2.0.0] - 2022-02-10
 
 ### Added

--- a/argo-connectors.spec
+++ b/argo-connectors.spec
@@ -2,7 +2,7 @@
 %global __python /usr/bin/python3
 
 Name:    argo-connectors
-Version: 2.0.0
+Version: 2.1.0
 Release: 1%{?dist}
 Group:   EGI/SA4
 License: ASL 2.0

--- a/argo-connectors.spec
+++ b/argo-connectors.spec
@@ -58,5 +58,7 @@ rm -rf $RPM_BUILD_ROOT
 %attr(0755,root,root) %dir %{_localstatedir}/log/argo-connectors/
 
 %changelog
+* Tue Jun  7 2022 Daniel Vrcic <dvrcic@srce.hr> - 2.1.0-1%{dist}
+- spec changes to reflect new pkg and py module argo-connectors name
 * Thu Feb 10 2022 Daniel Vrcic <dvrcic@srce.hr> - 2.0.0-1%{dist}
 - release of async-enabled connectors with additional CSV and JSON topologies


### PR DESCRIPTION
## [2.1.0] - 2022-06-07

### Added

* ARGO-2862 Introduce topo, weights, downtimes and metricprofile individual async tasks
* ARGO-3583 Add support in Connectors for EOSC Providers Portal API
* ARGO-3666 Introduce service type and descriptions fetch
* ARGO-3700 EOSC topology service endpoints with only one hardcoded service for start
* ARGO-3803 Use id as a service group name for EOSC PROVIDER topology
* ARGO-3818 Use id as a project name for EOSC PROVIDER topology instead of abbreviation
* ARGO-3849 Fetch monitoring extensions

### Fixed

* ARGO-3708 EOSCPROVIDER contacs is wrongly populated with one contact for every different endpoint
* ARGO-3858 Slow performance with mesh of contacts data for EOSCPROVIDER topo
* ARGO-3861 Some of endpoints are skipped if multiple endpoints are defined for the same resource on service-extensions
* ARGO-3866 EOSC topology issue when defining two endpoints with the same hostname/service-type through monitoring extensions
* ARGO-3869 Strip port from extracted hostname in group endpoints

### Changed

* ARGO-3842 Rename py modules and pkg to argo-connectors
* ARGO-3846 Do not assume first fetch with paginated indexes succesfull
* ARGO-3855 Join error lines for PROVIDER topology
* ARGO-3856 find_next_paging_cursor_count for GOCDB topo task implies succesfull parse