### PR TITLE
Version 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.2.1] - 2022-11-03
+
+### Added
+
+* ARGO-4011 Fetch Horizontal services from PROVIDERS portal
+
+### Fixed
+
+* ARGO-4057 Downtimes GOCDB connector does not take into account AuthN options
+* ARGO-4099 Do not try to parse EXTENSIONS for GOCDB sub services
+
 ## [2.2.0] - 2022-07-28
 
 ### Added

--- a/argo-connectors.spec
+++ b/argo-connectors.spec
@@ -2,13 +2,13 @@
 %global __python /usr/bin/python3
 
 Name:    argo-connectors
-Version: 2.2.0
+Version: 2.2.1
 Release: 1%{?dist}
 Group:   EGI/SA4
 License: ASL 2.0
 Summary: Components fetch and transform data that represents input for ARGO Compute Engine
 Url:     https://github.com/ARGOeu/argo-connectors/
-Vendor:  SRCE <dvrcic@srce.hr>, SRCE <kzailac@srce.hr>
+Vendor:  SRCE <dvrcic@srce.hr>
 
 Obsoletes: argo-egi-connectors
 Prefix:    %{_prefix}


### PR DESCRIPTION
### Added

* ARGO-4011 Fetch Horizontal services from PROVIDERS portal

### Fixed

* ARGO-4057 Downtimes GOCDB connector does not take into account AuthN options
* ARGO-4099 Do not try to parse EXTENSIONS for GOCDB sub services
